### PR TITLE
Fix reference to touchicons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ ca
 docker-compose-prod.override.yml
 docker-compose.override.yml
 docker-compose*.override.yml
+
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ docker-compose-prod.override.yml
 docker-compose.override.yml
 docker-compose*.override.yml
 
+# Ignoring local vscode settings file
 .vscode/settings.json

--- a/src/static/browserconfig.xml
+++ b/src/static/browserconfig.xml
@@ -2,7 +2,7 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/mstile-150x150.png"/>
+            <square150x150logo src="/static/mstile-150x150.png"/>
             <TileColor>#ffffff</TileColor>
         </tile>
     </msapplication>

--- a/src/static/site.webmanifest
+++ b/src/static/site.webmanifest
@@ -3,12 +3,12 @@
     "short_name": "Etherpad",
     "icons": [
         {
-            "src": "/android-chrome-192x192.png",
+            "src": "/static/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-512x512.png",
+            "src": "/static/android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -8,7 +8,16 @@
         <meta charset="utf-8">
         <meta name="referrer" content="no-referrer">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+        
+        <link rel="apple-touch-icon" sizes="180x180" href="static/apple-touch-icon.png">
+        <link rel="icon" type="image/png" sizes="32x32" href="static/favicon-32x32.png">
+        <link rel="icon" type="image/png" sizes="16x16" href="static/favicon-16x16.png">
+        <link rel="manifest" href="static/site.webmanifest">
+        <link rel="mask-icon" href="static/safari-pinned-tab.svg" color="#5bbad5">
         <link rel="shortcut icon" href="favicon.ico">
+        <meta name="msapplication-TileColor" content="#2b5797">
+        <meta name="msapplication-config" content="static/browserconfig.xml">
+        <meta name="theme-color" content="#ffffff">
 
         <link rel="localizations" type="application/l10n+json" href="locales.json">
         <script type="text/javascript" src="static/js/vendors/html10n.js?v=<%=settings.randomVersionString%>"></script>


### PR DESCRIPTION
## Further Notes

- Adjustment are based on the recommendations of this favicon checker: https://realfavicongenerator.net/favicon_checker?protocol=https&site=pad.kits.blog#.Yzp1EC8RrT8

## Results

- Results of local favicon checker are successful

<img width="1904" alt="image" src="https://user-images.githubusercontent.com/592424/193508181-842ed866-909c-409e-a9f7-a1df589d669f.png">

## Checklist

- [x] Tested local configuration of favicons with `ngrok` and https://realfavicongenerator.net/favicon_checker