### PR TITLE
Making Etherpad service depend on MariaDB

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -24,7 +24,8 @@ services:
           ep_disable_imports
         INSTALL_SOFFICE: 'true'
     depends_on:
-      - mariadb_prod
+      mariadb_prod:
+        condition: service_healthy
     environment:
       DB_CHARSET: ${DOCKER_COMPOSE_APP_PROD_ENV_DB_CHARSET:-utf8mb4}
       DB_HOST: mariadb_prod
@@ -74,6 +75,17 @@ services:
       - ./ca/server.crt:/var/lib/mysql/server.crt
       - ./ca/server.key:/var/lib/mysql/server.key
       - mariadb_prod_data:/var/lib/mysql
+    healthcheck:
+      test:
+        - "CMD"
+        - "mysqladmin"
+        - "ping"
+        - "--host=localhost"
+        - "--user=${DOCKER_COMPOSE_MARIADB_PROD_ENV_MARIADB_USER:?}"
+        - "--password=${DOCKER_COMPOSE_MARIADB_PROD_ENV_MARIADB_PASSWORD:?}"
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   mariadb_prod_data:


### PR DESCRIPTION
## Further Notes

## New Features / Enhancements

- [x] Add healthcheck for mariadb_prod
- [x] Ensure that app waits for mariadb to be ready before starting (using `depends_on`)

## After Merge Checklist


<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->
