### PR TITLE
add back import for documents

### DIFF
--- a/settings.json.docker
+++ b/settings.json.docker
@@ -656,7 +656,7 @@
    * Allow only some file formats
    */
   "ep_disable_imports": {
-    "allow": []
+    "allow": ["etherpad", "txt"]
   },
 
   /*

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -88,7 +88,7 @@
 	"pad.settings.about": "Über",
 	"pad.settings.poweredBy": "Betrieben von",
 	"pad.importExport.import_export": "Import/Export",
-	"pad.importExport.import": "Textdatei oder Dokument hochladen",
+	"pad.importExport.import": "Textdatei hochladen",
 	"pad.importExport.importSuccessful": "Erfolgreich!",
 	"pad.importExport.export": "Aktuelles Pad exportieren als:",
 	"pad.importExport.exportetherpad": "Etherpad",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -97,7 +97,7 @@
 	"pad.importExport.exportword": "Microsoft Word",
 	"pad.importExport.exportpdf": "PDF",
 	"pad.importExport.exportopen": "ODF (Open Document Format)",
-	"pad.importExport.abiword.innerHTML": "Du kannst nur aus reinen Text- oder HTML-Formaten importieren. Für umfangreichere Importfunktionen <a href=\"https://github.com/ether/etherpad-lite/wiki/How-to-enable-importing-and-exporting-different-file-formats-with-AbiWord\">muss AbiWord oder LibreOffice auf dem Server installiert werden</a>.",
+	"pad.importExport.abiword.innerHTML": "Wähle bitte reine Text- oder HTML-Formate aus zum Importieren.",
 	"pad.modals.connected": "Verbunden.",
 	"pad.modals.reconnecting": "Dein Pad wird neu verbunden...",
 	"pad.modals.forcereconnect": "Erneutes Verbinden erzwingen",

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -178,7 +178,27 @@
       <!------------------------->
 
       <div id="import_export" class="popup"><div class="popup-content">
-          <h1>Export</h1>
+          <h1 data-l10n-id="pad.importExport.import_export"></h1>
+          <div class="acl-write">
+              <% e.begin_block("importColumn"); %>
+              <h2 data-l10n-id="pad.importExport.import"></h2>
+              <div class="importmessage" id="importmessageabiword" data-l10n-id="pad.importExport.abiword.innerHTML"></div><br>
+              <form id="importform" method="post" action="" target="importiframe" enctype="multipart/form-data">
+                  <div class="importformdiv" id="importformfilediv">
+                      <input type="file" name="file" size="10" id="importfileinput">
+                      <div class="importmessage" id="importmessagefail"></div>
+                  </div>
+                  <div id="import"></div>
+                  <div class="importmessage" id="importmessagesuccess" data-l10n-id="pad.importExport.importSuccessful"></div>
+                  <div class="importformdiv" id="importformsubmitdiv">
+                      <span class="nowrap">
+                          <input type="submit" class="btn btn-primary" name="submit" value="Import Now" disabled="disabled" id="importsubmitinput">
+                          <div alt="" id="importstatusball" class="loadingAnimation" align="top"></div>
+                      </span>
+                  </div>
+              </form>
+              <% e.end_block(); %>
+          </div>
           <div id="exportColumn">
               <h2 data-l10n-id="pad.importExport.export"></h2>
               <% e.begin_block("exportColumn"); %>


### PR DESCRIPTION
<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->
